### PR TITLE
Fix folder path in Nexus README

### DIFF
--- a/nexus/README.md
+++ b/nexus/README.md
@@ -15,7 +15,7 @@ Il progetto si ispira a dashboard moderne come Grafana e al mondo della blockcha
 - **Requisiti**: Node.js (v14+), npm, TronLink (estensione Chrome/Firefox).
 - **Passaggi**:
   1. Clona il repository: `git clone https://github.com/BlockRockAdmin/BlockRock.git`.
-  2. Entra nella directory: `cd blockrock-nexus`.
+  2. Entra nella directory: `cd nexus`.
   3. Installa le dipendenze: `npm install`.
   4. Avvia in modalità sviluppo: `npm run dev`.
   5. Accedi da browser: `http://localhost:5173` o `http://<IP-LAN>:5173`.


### PR DESCRIPTION
## Summary
- correct the folder name in Nexus installation instructions

## Testing
- `cargo test --workspace --no-run` *(fails: could not finish due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_688a716caefc8323b28cbf11aaa44695