### PR TITLE
Fix custom event export typo

### DIFF
--- a/zion-core/src/network/mod.rs
+++ b/zion-core/src/network/mod.rs
@@ -2,4 +2,4 @@
 pub mod p2p;
 
 // Esporta la funzione e il tipo di evento P2P aggiornati
-pub use p2p::{start_p2p_node, CustomEvent as  MyBehaviourEvent}; // `MyBehaviourEvent` è l'OutEvent del nostro comportamento
+pub use p2p::{start_p2p_node, CustomEvent as MyBehaviourEvent}; // CustomEvent è l'OutEvent del nostro comportamento


### PR DESCRIPTION
## Summary
- tidy spacing in the `p2p` re-export
- clarify comment describing `CustomEvent`

## Testing
- `cargo check --manifest-path zion-core/Cargo.toml -q` *(failed: compilation too heavy for environment)*

------
https://chatgpt.com/codex/tasks/task_e_688a7cbfb71c8323adb538a361ceeceb