### PR TITLE
Use relative .env path in run_node.sh

### DIFF
--- a/run_node.sh
+++ b/run_node.sh
@@ -1,12 +1,22 @@
 #!/bin/bash
 set -e
-ENV_FILE=~/Documents/BlockRock/.env
+
+# Determine the directory where this script resides
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Allow overriding the location of the .env file via BLOCKROCK_ENV
+ENV_FILE="${BLOCKROCK_ENV:-"$SCRIPT_DIR/.env"}"
+
 if [ ! -f "$ENV_FILE" ]; then
     echo "Error: .env file not found at $ENV_FILE"
     exit 1
 fi
+
+# Load environment variables required by the node
 source "$ENV_FILE"
 export TRONGRIDAPIKEY
 export TRON_ADDRESS
-cd ~/Documents/BlockRock/zion-core
+
+# Run the node from the zion-core directory relative to the script
+cd "$SCRIPT_DIR/zion-core"
 cargo +nightly run --release --bin node


### PR DESCRIPTION
## Summary
- update `run_node.sh` to load the `.env` file relative to the script directory
- allow overriding the env file location with `BLOCKROCK_ENV`
- run node from the relative `zion-core` directory

## Testing
- `cargo test --workspace --locked` *(failed: build dependencies not present)*

------
https://chatgpt.com/codex/tasks/task_e_688bd7a6e2588323bbc1713ab15b2ea8