### PR TITLE
Enhance core with chain validation and persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,11 +402,14 @@ dependencies = [
 name = "blockrock-core-lib"
 version = "0.1.0"
 dependencies = [
+ "blake2",
  "ed25519-dalek",
  "hex",
  "rand 0.8.5",
  "serde",
+ "serde_json",
  "sha2",
+ "tempfile",
 ]
 
 [[package]]

--- a/blockrock-core/Cargo.toml
+++ b/blockrock-core/Cargo.toml
@@ -14,3 +14,7 @@ blake2 = "0.10"
 ed25519-dalek = { version = "2.0.0", features = ["rand_core", "pkcs8", "serde"] }
 rand = "0.8"
 hex = "0.4"
+serde_json = "1.0"
+
+[dev-dependencies]
+tempfile = "3"

--- a/blockrock-core/README.md
+++ b/blockrock-core/README.md
@@ -15,3 +15,11 @@ Il modulo fa parte del workspace Rust del repository, quindi viene compilato aut
 ## Integrazione con il progetto
 
 `blockrock-core` è importato da `zion-core` e da altri servizi per esporre funzionalità blockchain comuni. Le librerie generate possono essere riutilizzate da applicazioni Rust esterne o da moduli aggiuntivi della piattaforma.
+
+## Funzionalità aggiuntive
+
+Oltre alle strutture di base per blocchi e transazioni, il modulo offre ora:
+
+- verifica dell'integrità della catena (`validate_chain`)
+- funzioni di persistenza per salvare e caricare la blockchain in formato JSON
+

--- a/blockrock-core/src/block.rs
+++ b/blockrock-core/src/block.rs
@@ -56,4 +56,9 @@ impl Block {
         let hash_slice = &result[..32];
         hex::encode(hash_slice)
     }
+
+    /// Verifica che l'hash memorizzato nel blocco sia corretto
+    pub fn is_hash_valid(&self) -> bool {
+        self.calculate_hash() == self.hash
+    }
 }

--- a/blockrock-core/src/transaction.rs
+++ b/blockrock-core/src/transaction.rs
@@ -1,6 +1,6 @@
-use serde::{Serialize, Deserialize};
-use ed25519_dalek::{SigningKey, VerifyingKey, Signer, Verifier, Signature};
-use sha2::{Sha256, Digest};
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::fmt;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -65,6 +65,10 @@ impl Transaction {
 
 impl fmt::Display for Transaction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Transaction: {} -> {} ({}, id: {})", self.sender, self.receiver, self.amount, self.id)
+        write!(
+            f,
+            "Transaction: {} -> {} ({}, id: {})",
+            self.sender, self.receiver, self.amount, self.id
+        )
     }
 }

--- a/blockrock-core/tests/persistence.rs
+++ b/blockrock-core/tests/persistence.rs
@@ -1,0 +1,24 @@
+use blockrock_core::blockchain::Blockchain;
+use blockrock_core::transaction::Transaction;
+use ed25519_dalek::SigningKey;
+use tempfile::tempdir;
+
+#[test]
+fn save_and_load_chain() {
+    let mut chain = Blockchain::new("Node1".to_string());
+
+    let key = SigningKey::generate(&mut rand::thread_rng());
+    chain.add_public_key("Alice", key.verifying_key());
+
+    let tx = Transaction::new("Alice".to_string(), "Bob".to_string(), 5.0, &key);
+    assert!(chain.add_block(vec![tx], "Node1".to_string()));
+    assert!(chain.validate_chain());
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("chain.json");
+    chain.save_to_file(&path).unwrap();
+
+    let loaded = Blockchain::load_from_file(&path).unwrap();
+    assert!(loaded.validate_chain());
+    assert_eq!(loaded.blocks.len(), chain.blocks.len());
+}


### PR DESCRIPTION
## Summary
- add serde_json and tempfile dependencies
- implement block hash validation method
- add blockchain validation and JSON persistence helpers
- document new features in `blockrock-core` README
- add a persistence test for the blockchain

## Testing
- `cargo test -p blockrock-core-lib`

------
https://chatgpt.com/codex/tasks/task_e_688be13ed7688323bab780b8710c4a55